### PR TITLE
Fixes for batch norm docs

### DIFF
--- a/docs/guides/training_techniques/batch_norm.rst
+++ b/docs/guides/training_techniques/batch_norm.rst
@@ -221,7 +221,7 @@ In addition, update your ``train_step`` function to reflect these changes:
         {'params': params},
         x=batch['image'])
       loss = optax.softmax_cross_entropy_with_integer_labels(
-        logits=logits, labels=batch['label'])
+        logits=logits, labels=batch['label']).mean()
       return loss, logits
     grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
     (loss, logits), grads = grad_fn(state.params)
@@ -241,7 +241,7 @@ In addition, update your ``train_step`` function to reflect these changes:
         {'params': params, 'batch_stats': state.batch_stats},  #!
         x=batch['image'], train=True, mutable=['batch_stats']) #!
       loss = optax.softmax_cross_entropy_with_integer_labels(
-        logits=logits, labels=batch['label'])
+        logits=logits, labels=batch['label']).mean()
       return loss, (logits, updates) #!
     grad_fn = jax.value_and_grad(loss_fn, has_aux=True)
     (loss, (logits, updates)), grads = grad_fn(state.params) #!
@@ -269,7 +269,7 @@ and the ``train`` argument is set to ``False``:
       {'params': params},
       x=batch['image'])
     loss = optax.softmax_cross_entropy_with_integer_labels(
-      logits=logits, labels=batch['label'])
+      logits=logits, labels=batch['label']).mean()
     metrics = {
       'loss': loss,
         'accuracy': jnp.mean(jnp.argmax(logits, -1) == batch['label']),
@@ -278,12 +278,12 @@ and the ``train`` argument is set to ``False``:
   ---
   @jax.jit
   def eval_step(state: TrainState, batch):
-    """Train for a single step."""
+    """Evaluate for a single step."""
     logits = state.apply_fn(
-      {'params': params, 'batch_stats': state.batch_stats}, #!
+      {'params': state.params, 'batch_stats': state.batch_stats}, #!
       x=batch['image'], train=False) #!
     loss = optax.softmax_cross_entropy_with_integer_labels(
-      logits=logits, labels=batch['label'])
+      logits=logits, labels=batch['label']).mean()
     metrics = {
       'loss': loss,
         'accuracy': jnp.mean(jnp.argmax(logits, -1) == batch['label']),


### PR DESCRIPTION
Changes:
 - Fixed reference to `params` in `eval_step`
 - Fixed the docstring in `eval_step`
 - Added `.mean()` to losses


The documentation for batch norm is written in such a way, that directly copying from it results in an unpleasant bug where the `params`  used in `eval_step` refer to the initial parameters of the network. This causes metrics to show that the model is not generalising to the test set at all. This change hopefully saves someone else learning flax a similar scratch on the head.

<!--

Great, you are contributing to Flax!

But... please read the following carefully so we can make sure your PR is merged
easily.

Replace this text block with a description of the change and which issue it
fixes (if applicable). Please also include relevant motivation/context.

Once you're done, someone in the Flax team will review your PR shortly. They may
suggest changes to make the code even better. If no one reviewed your PR after a
week has passed, don't hesitate to post a new comment @-mentioning the same
persons (sometimes notifications get lost).
-->

## Checklist
- [x] This PR fixes a minor issue (e.g.: typo or small bug) or improves the docs (you can dismiss the other
      checks if that's the case).
